### PR TITLE
Fix IFrame Loading Exception

### DIFF
--- a/intro-to-iiif/LEAFLET-IIIF.html
+++ b/intro-to-iiif/LEAFLET-IIIF.html
@@ -399,7 +399,7 @@
                                 <h1 id="leaflet-iiif">Leaflet-IIIF</h1>
 <p><a href="https://github.com/mejackreed/Leaflet-IIIF" target="_blank">Leaflet-IIIF</a> is a JavaScript library for creating zoomable views of IIIF images. It is a plugin for the popular library <a href="http://leafletjs.com/" target="_blank">LeafletJS</a>.</p>
 <p>Here is an example:</p>
-<iframe src="http://mejackreed.github.io/Leaflet-IIIF/examples/example.html" frameborder="0" width="100%" height="500px"></iframe>
+<iframe src="https://mejackreed.github.io/Leaflet-IIIF/examples/example.html" frameborder="0" width="100%" height="500px"></iframe>
 
 <p>Leaflet-IIIF allows you to use the expressivity of Leaflet and its plugin ecosystem all at the same time to display IIIF images.</p>
 <p>Let&apos;s take a look at that Leaflet-IIIF instance and how it works.</p>


### PR DESCRIPTION
This was originally reported in https://github.com/IIIF/training/issues/1, so here's the fix!

GH Pages are now served over https so having an iframe linked to an http
will throw a mixed content warning and most browsers wont load the IFrame content
(at least chrome won't)