### PR TITLE
Adds gitbook link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # training
 Documentation and workshop materials for IIIF training
+[View the gitbook](https://iiif.github.io/training/intro-to-iiif/).


### PR DESCRIPTION
We were having trouble finding the link today in the software devs call. Helpful to have a link from the repo readme. 